### PR TITLE
Update readmissions model for bug

### DIFF
--- a/models/_models.yml
+++ b/models/_models.yml
@@ -272,6 +272,9 @@ models:
     columns:
       - name: encounter_id
         description: "The unique identifier for the encounter"
+        tests:
+          - unique
+          - not_null
       - name: patient_id
         description: "The unique identifier for the patient"
       - name: admit_date

--- a/models/readmissions__encounter_augmented.sql
+++ b/models/readmissions__encounter_augmented.sql
@@ -3,10 +3,17 @@
 -- and we augment them with extra fields
 -- that are relevant for readmission measures
 
+/* Update 9/12/23 Including encounters that were previously eliminated because of a flaw in the logic for 
+overlapping encounters */
 
 {{ config(enabled=var('readmissions_enabled',var('tuva_packages_enabled',True))) }}
 
-select
+
+
+
+
+
+, tuva_model as (select
     aa.encounter_id,
     aa.patient_id,
     aa.admit_date,
@@ -52,4 +59,6 @@ from
     left join {{ ref('readmissions__encounter_specialty_cohort') }} dd
     on aa.encounter_id = dd.encounter_id
     left join {{ ref('readmissions__encounter_data_quality') }} ee
-    on aa.encounter_id = ee.encounter_id
+    on aa.encounter_id = ee.encounter_id) 
+
+    

--- a/models/readmissions__encounter_augmented.sql
+++ b/models/readmissions__encounter_augmented.sql
@@ -8,12 +8,7 @@ overlapping encounters */
 
 {{ config(enabled=var('readmissions_enabled',var('tuva_packages_enabled',True))) }}
 
-
-
-
-
-
-, tuva_model as (select
+select
     aa.encounter_id,
     aa.patient_id,
     aa.admit_date,
@@ -59,6 +54,6 @@ from
     left join {{ ref('readmissions__encounter_specialty_cohort') }} dd
     on aa.encounter_id = dd.encounter_id
     left join {{ ref('readmissions__encounter_data_quality') }} ee
-    on aa.encounter_id = ee.encounter_id) 
+    on aa.encounter_id = ee.encounter_id
 
     

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -83,7 +83,7 @@ from dates
 where row_number_keep is not null
 order by admit_date)
 
-, join_setup as( select *
+, discharge_join_setup as( select *
 , lag(encounter_id) over (partition by patient_id order by row_count desc) as admit_encounter_id
 from add_row_number)
 
@@ -98,7 +98,7 @@ where first_row_flag )
 , discharge_date
 , admit_encounter_id
 , row_number () over  (partition by patient_id, disqualified_encounter_flag order BY discharge_date desc)  as admit_rank
-from join_setup
+from discharge_join_setup
 where last_row_flag 
 )
 
@@ -109,28 +109,6 @@ where last_row_flag
 , admits.admit_date
 , discharge.discharge_date
 , discharge_disposition_code
-, facility_npi
-, ms_drg_code
-, paid_amount
-, date_diff( discharge.discharge_date, admits.admit_date, day) as length_of_stay
-, index_admission_flag 
-, planned_flag
-, specialty_cohort
-, died_flag
-, diagnosis_ccs
-, disqualified_encounter_flag
-, missing_admit_date_flag
-, missing_discharge_date_flag
-, admit_after_discharge_flag
-, missing_discharge_disposition_code_flag
-, invalid_discharge_disposition_code_flag
-, missing_primary_diagnosis_flag
-, multiple_primary_diagnoses_flag
-, invalid_primary_diagnosis_code_flag
-, no_diagnosis_ccs_flag
-, 0 as overlaps_with_another_encounter_flag
-, missing_ms_drg_flag
-, invalid_ms_drg_flag
 
 from admits
 left join discharge 
@@ -159,13 +137,42 @@ select encounter_id
 , admit_date
 , discharge_date
 from multiple_transfers_one_row_final t
-
 )
 
-select *
-from transfers_combined_final
+, add_in_final_fields as (
 
-/*
+select 
+ f.encounter_id
+, f.patient_id
+, f.admit_date
+, f.discharge_date
+, discharge_disposition_code
+, facility_npi
+, ms_drg_code
+, paid_amount
+, date_diff( discharge.discharge_date, admits.admit_date, day) as length_of_stay
+, index_admission_flag 
+, planned_flag
+, specialty_cohort
+, died_flag
+, diagnosis_ccs
+, disqualified_encounter_flag
+, missing_admit_date_flag
+, missing_discharge_date_flag
+, admit_after_discharge_flag
+, missing_discharge_disposition_code_flag
+, invalid_discharge_disposition_code_flag
+, missing_primary_diagnosis_flag
+, multiple_primary_diagnoses_flag
+, invalid_primary_diagnosis_code_flag
+, no_diagnosis_ccs_flag
+, 0 as overlaps_with_another_encounter_flag
+, missing_ms_drg_flag
+, invalid_ms_drg_flag
+from transfers_combined_final f
+left join encounter_sequence_setup_multiple_transfers e
+on f.encounter_id=e.encounter_id
+)
 
 , join_together_encounter_sequence as (
 select *
@@ -235,4 +242,3 @@ select *
 from readmission_calc
 
 
-*/

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -240,5 +240,5 @@ from
 
 select *
 from readmission_calc
-
+where length_of_stay < 120
 

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -163,7 +163,7 @@ from multiple_transfers_one_row_final t
 )
 
 select *
-from transfers_combined
+from transfers_combined_final
 
 /*
 

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -179,7 +179,7 @@ select *
 from encounter_sequence
 union all
 select *
-from join_admits_discharge)
+from from add_in_final_fields)
 
 , add_encounter_seq as (
 select * 

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -150,7 +150,7 @@ select
 , facility_npi
 , ms_drg_code
 , paid_amount
-, date_diff(discharge_date, admit_date, day) as length_of_stay
+, date_diff(f.discharge_date, f.admit_date, day) as length_of_stay
 , index_admission_flag 
 , planned_flag
 , specialty_cohort

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -179,7 +179,7 @@ select *
 from encounter_sequence
 union all
 select *
-from from add_in_final_fields)
+from add_in_final_fields)
 
 , add_encounter_seq as (
 select * 

--- a/models/readmissions__readmission_summary.sql
+++ b/models/readmissions__readmission_summary.sql
@@ -150,7 +150,7 @@ select
 , facility_npi
 , ms_drg_code
 , paid_amount
-, date_diff( discharge.discharge_date, admits.admit_date, day) as length_of_stay
+, date_diff(discharge_date, admit_date, day) as length_of_stay
 , index_admission_flag 
 , planned_flag
 , specialty_cohort


### PR DESCRIPTION
## Describe your changes
This adds logic to include index admissions when the following encounters are transfers. Currently in the TUVA model (will post to their slack), if an index admission has 1 or more encounters after it with admit/discharge dates the same as the encounter before it, then there is a flag that is created that indicates these are overlapping encounters and all 3 encounters are removed. 

However, we want to keep the first admit date and last encounters' discharge date for further readmission counting. Also commenting out the paid_amount because it will be incorrect as we are combining data from multiple rows.

Also removing lengths of stay over 120 days, those are likely errors in 1 of 2 scenarios I accounted for, this removes around 120 encounters total.

This change adds 2,175 encounters, about a 10% increase and 660+ readmissions overall. 

**Looker Dashboards that be impacted:** 

- Account management dashboard, counts of readmissions 

Another review that this example shows this was a transfer

```
select *
from production-dna.analytics_int.encounter
--production-dna.analytics_int.stg_encounter
--production-dna.analytics_int.encounter_data_quality
where encounter_id in ('1002032226392', '1002032226413', '1002057086018')


```

```
select count(distinct encounter_id)
 from `pre-production-dna.dbt_lrosenbluth_int.readmission_summary` 
 where readmit_30_flag=1
--19023
--readmit number 3679
 ;

 select count(distinct encounter_id)

 from `production-dna.analytics_int.readmission_summary` 
  where readmit_30_flag=1

```

Example encounter id's '1002032226392', '1002032226413', '1002057086018' , can look in production-dna.analytics_int.encounter_data_quality

## How has this been tested?
Unique and not null tests on the yml
Counts and tests in BQ along with visual inspection of records. 

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.

## Checklist before requesting a review
- [x]  My code follows style guidelines
- [x]  I have tested my code by running `dbt build` in **BigQuery**
- [x]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)
https://tenor.com/view/rod-serling-youve-entered-the-burnout-zone-gif-16697452

